### PR TITLE
Minor additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# [dash-postfix](https://github.com/fnkr/dash-postfix)
+
+[Dash](https://kapeli.com/dash) docset generator for [Postfix](http://www.postfix.org) documentation.
+
+## Usage
+
+**1)** Install the [dashing](https://github.com/technosophos/dashing.git) docset generator.
+**2)** Clone this git repository.
+**3)** `./fetch_remote_content.sh` to ownload the postfix documentation.
+**4)** `dashing build` to generate the Dash docset.
+**5)** Import into Dash by double-clicking the docset file.

--- a/dashing.json
+++ b/dashing.json
@@ -9,6 +9,10 @@
             "type": "Directive",
             "matchpath": ".*\\.[0-9]+\\.html$"
         },
+        "body>dl>dd>dl>dt>b> a[name]": {
+            "type": "Parameter",
+            "matchpath": ".*\\.[0-9]+\\.html$"
+        },
         "head>title": {
             "type": "Command",
             "regexp": "^Postfix manual -[\\n\\t\\s]*",

--- a/fetch_remote_content.sh
+++ b/fetch_remote_content.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+POSTFIXVERSION='3.2.2'
 rm -rf www.postfix.org/
-wget \
-    --recursive --level=1 --domains www.postfix.org \
-    --html-extension --restrict-file-names=windows \
-    --page-requisites --no-clobber \
-    http://www.postfix.org/postfix-manuals.html
+wget "http://cdn.postfix.johnriley.me/mirrors/postfix-release/official/postfix-${POSTFIXVERSION}.tar.gz"
+tar xzf "postfix-${POSTFIXVERSION}.tar.gz"
+mv "postfix-${POSTFIXVERSION}/HTML" www.postfix.org
+rm -f "postfix-${POSTFIXVERSION}.tar.gz"
+rm -rf "postfix-${POSTFIXVERSION}"


### PR DESCRIPTION
Hey there,

The following changes download the postfix documentation html files directly from the source code, as various files were missing with the previous `wget` crawler. I also added parsing of additional postfix parameters (eg `smtpd_recipient_restrictions` options) to ease their retrieval in Dash, as well as a small readme to explain how to use this repository.